### PR TITLE
Feature: Emote Scramble

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ configs
 .mypy_cache
 stderr.log.*
 stdout.log.*
+venv

--- a/main.py
+++ b/main.py
@@ -720,7 +720,7 @@ since new scramble round started."
             if t == EMOTE_SCRAMBLE_TIMEOUT and emote_scramble_started is True:
                 await msg.reply(
                     '[Emote Scramble] No one answered correctly. FeelsBadMan '
-                    f'The word was: " {emote_scramble_word["unscrambled_emote_code"]} "'
+                    f'The emote was: " {emote_scramble_word["unscrambled_emote_code"]} "'
                 )
                 emote_scramble_started = False
                 return  # TODO: is break or return better here?

--- a/main.py
+++ b/main.py
@@ -291,8 +291,6 @@ class BlammoBot(BaseBot):
         # if not self.stream_online and 'toggletimetest' in msg.content and msg.author == 'diraction':
         #     self.stream_online = True
 
-        self.stream_online = False
-        self.stream_online_prev = False
         if self.stream_online == True and self.stream_online_prev == False:
             await msg.reply(f"Bedge 💤 honk shoo Bedge 💤 mimimimi")
             logger.info(

--- a/utils/emote_scramble.py
+++ b/utils/emote_scramble.py
@@ -1,0 +1,131 @@
+import random
+from typing import TypedDict
+from .third_party_emotes import (
+    ThirdPartyEmoteProvider,
+    BetterTTVEmoteProvider,
+    FrankerFaceZEmoteProvider,
+    FailedToFetchEmotesException,
+)
+from .string_utils import (
+    safe_scramble_word,
+    AttemptedToScrambleWordWithLessThanTwoChars,
+    ScrambleAttemptsExceededException,
+)
+
+# START: Logging
+
+import logging
+from log.loggers.custom_format import CustomFormatter  # for level colors
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+formatter1 = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s : %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+file_handler = logging.FileHandler("logs.log")
+file_handler.setFormatter(formatter1)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(CustomFormatter())
+
+logger.addHandler(file_handler)
+logger.addHandler(stream_handler)
+
+# END: Logging
+
+
+class FailedToGetEmoteScrambleWord(Exception):
+    pass
+
+
+class EmoteScrambleWord(TypedDict):
+    scrambled_emote_code_lower: str
+    scrambled_emote_code: str
+    unscrambled_emote_code: str
+
+
+class EmoteScrambleData:
+    user_id: int
+    third_party_emote_providers: list[ThirdPartyEmoteProvider] = []
+
+    BANNED_EMOTE_CODES = [  # TODO: Make this configurable externally
+        "haHAA",
+        "PepeLa",
+        "dankHug",
+    ]
+
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
+        self.third_party_emote_providers = [
+            BetterTTVEmoteProvider(user_id=user_id),
+            FrankerFaceZEmoteProvider(user_id=user_id),
+        ]
+
+    def get_emote_scramble_word(self) -> EmoteScrambleWord:
+        last_exception = None
+
+        MAX_ATTEMPTS = 100
+
+        for _ in range(MAX_ATTEMPTS):
+            third_party_emote_provider = random.choice(self.third_party_emote_providers)
+
+            try:
+                random_emote_code = third_party_emote_provider.get_random_emote_code()
+            except FailedToFetchEmotesException as e:
+                last_exception = e
+                continue
+
+            # Prevent two-character emotes (e.g. BetterTTV's emote modifiers like `w!`)
+            # from being returned
+            if len(random_emote_code) <= 2:
+                logger.debug(
+                    f"Skipping {random_emote_code} because it has 2 or less characters."
+                )
+                continue
+
+            # Prevent banned emotes from being returned
+            elif random_emote_code in self.BANNED_EMOTE_CODES:
+                logger.debug(
+                    f"Skipping {random_emote_code} because it is a banned emote."
+                )
+                continue
+
+            try:
+                scrambled_random_emote_code_lower = safe_scramble_word(
+                    random_emote_code
+                ).lower()
+                scrambled_random_emote_code = safe_scramble_word(random_emote_code)
+            except (
+                AttemptedToScrambleWordWithLessThanTwoChars,
+                ScrambleAttemptsExceededException,
+            ) as e:
+                last_exception = e
+                logger.warn(f"Failed to scramble word: {random_emote_code} ({e})")
+                continue
+
+            logger.debug(f"Emote scramble answer: {random_emote_code}")
+
+            return {
+                "scrambled_emote_code_lower": scrambled_random_emote_code_lower,
+                "scrambled_emote_code": scrambled_random_emote_code,
+                "unscrambled_emote_code": random_emote_code,
+            }
+
+        if last_exception:
+            raise FailedToGetEmoteScrambleWord from last_exception
+        raise FailedToGetEmoteScrambleWord
+
+    def reload_emotes(self) -> None:
+        for emote_provider in self.third_party_emote_providers:
+            try:
+                emote_provider.fetch_and_cache_emote_codes()
+            except FailedToFetchEmotesException as e:
+                raise e
+
+    def get_cached_emote_counts(self) -> dict:
+        return {
+            emote_provider.__class__.__name__: emote_provider.get_cached_emote_count()
+            for emote_provider in self.third_party_emote_providers
+        }

--- a/utils/string_utils.py
+++ b/utils/string_utils.py
@@ -1,0 +1,34 @@
+import random
+
+
+class AttemptedToScrambleWordWithLessThanTwoChars(Exception):
+    pass
+
+
+class ScrambleAttemptsExceededException(Exception):
+    pass
+
+
+def safe_scramble_word(word: str) -> str:
+    """
+    Provides a safe way to scramble a word.
+
+    - Prevents from scrambling words with less than 2 characters.
+    - Puts a maximum cap on the number of attempts to scramble the word
+      to prevent infinite loops from emotes like `AAAA`.
+    """
+
+    MAX_ATTEMPTS = 500
+
+    if len(word) < 2:
+        raise AttemptedToScrambleWordWithLessThanTwoChars
+
+    chars = list(word)
+
+    for _ in range(MAX_ATTEMPTS):
+        random.shuffle(chars)
+        scrambled_word = "".join(chars)
+        if scrambled_word != word:
+            return scrambled_word
+
+    raise ScrambleAttemptsExceededException

--- a/utils/string_utils.py
+++ b/utils/string_utils.py
@@ -28,7 +28,7 @@ def safe_scramble_word(word: str) -> str:
     for _ in range(MAX_ATTEMPTS):
         random.shuffle(chars)
         scrambled_word = "".join(chars)
-        if scrambled_word != word:
+        if scrambled_word.lower() != word.lower():
             return scrambled_word
 
     raise ScrambleAttemptsExceededException

--- a/utils/third_party_emotes.py
+++ b/utils/third_party_emotes.py
@@ -47,6 +47,10 @@ class ThirdPartyEmoteProvider:
         emote_codes = []
         emote_codes.extend(self.fetch_global_emote_codes())
         emote_codes.extend(self.fetch_channel_emote_codes())
+        logger.debug(
+            f"Caching {len(emote_codes)} emotes for {self.__class__.__name__}: "
+            f"{emote_codes}"
+        )
         self.cached_emote_codes = emote_codes
 
     def fetch_global_emote_codes(self) -> list[str]:

--- a/utils/third_party_emotes.py
+++ b/utils/third_party_emotes.py
@@ -1,0 +1,114 @@
+import random
+import requests
+
+# START: Logging
+
+import logging
+from log.loggers.custom_format import CustomFormatter  # for level colors
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+formatter1 = logging.Formatter(
+    "%(asctime)s - %(name)s - %(levelname)s : %(message)s",
+    datefmt="%m/%d/%Y %I:%M:%S %p",
+)
+file_handler = logging.FileHandler("logs.log")
+file_handler.setFormatter(formatter1)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(CustomFormatter())
+
+logger.addHandler(file_handler)
+logger.addHandler(stream_handler)
+
+# END: Logging
+
+
+class FailedToFetchEmotesException(Exception):
+    pass
+
+
+class ThirdPartyEmoteProvider:
+    cached_emote_codes: list[str] = []
+
+    def __init__(self, user_id: int) -> None:
+        self.user_id = user_id
+
+    def get_random_emote_code(self) -> str:
+        if len(self.cached_emote_codes) < 1:
+            self.fetch_and_cache_emote_codes()
+        return random.choice(self.cached_emote_codes)
+
+    def get_cached_emote_count(self) -> int:
+        return len(self.cached_emote_codes)
+
+    def fetch_and_cache_emote_codes(self) -> None:
+        emote_codes = []
+        emote_codes.extend(self.fetch_global_emote_codes())
+        emote_codes.extend(self.fetch_channel_emote_codes())
+        self.cached_emote_codes = emote_codes
+
+    def fetch_global_emote_codes(self) -> list[str]:
+        raise NotImplementedError
+
+    def fetch_channel_emote_codes(self) -> list[str]:
+        raise NotImplementedError
+
+    def get_global_emotes_api_url(self) -> str:
+        raise NotImplementedError
+
+    def get_channel_emotes_api_url(self) -> str:
+        raise NotImplementedError
+
+    def make_request(self, url) -> requests.Response:
+        logger.debug("Fetching emotes from %s", url)
+
+        resp = requests.get(url)
+        if resp.ok:
+            return resp
+
+        logger.error(f"Failed to fetch emotes from {url}")
+        raise FailedToFetchEmotesException
+
+
+class BetterTTVEmoteProvider(ThirdPartyEmoteProvider):
+    def fetch_global_emote_codes(self) -> list[str]:
+        resp = self.make_request(self.get_global_emotes_api_url())
+        return [emote["code"] for emote in resp.json()]
+
+    def fetch_channel_emote_codes(self) -> list[str]:
+        resp = self.make_request(self.get_channel_emotes_api_url())
+        channel_emotes = [emote["code"] for emote in resp.json()["channelEmotes"]]
+        shared_emotes = [emote["code"] for emote in resp.json()["sharedEmotes"]]
+        return channel_emotes + shared_emotes
+
+    def get_global_emotes_api_url(self) -> str:
+        return "https://api.betterttv.net/3/cached/emotes/global"
+
+    def get_channel_emotes_api_url(self) -> str:
+        return f"https://api.betterttv.net/3/cached/users/twitch/{self.user_id}"
+
+
+class FrankerFaceZEmoteProvider(ThirdPartyEmoteProvider):
+    def fetch_global_emote_codes(self) -> list[str]:
+        resp = self.make_request(self.get_global_emotes_api_url())
+        global_emote_set = "3"
+        return [
+            emote["name"]
+            for emote in resp.json()["sets"][global_emote_set]["emoticons"]
+        ]
+
+    def fetch_channel_emote_codes(self) -> list[str]:
+        resp = self.make_request(self.get_channel_emotes_api_url())
+        resp_json = resp.json()
+        room_emote_set = str(resp_json["room"]["set"])
+        return [
+            emote["name"] for emote in resp_json["sets"][room_emote_set]["emoticons"]
+        ]
+
+    def get_global_emotes_api_url(self) -> str:
+        return "https://api.frankerfacez.com/v1/set/global"
+
+    def get_channel_emotes_api_url(self) -> str:
+        return f"https://api.frankerfacez.com/v1/room/id/{self.user_id}"


### PR DESCRIPTION
When merged, this pull request will add a new game called Emote Scramble.

When initiated with the command `[prefix]escramble`, the bot will randomly choose between BetterTTV and FrankerFaceZ and pull the channel's emotes and the emote provider's global emotes.

A random emote code from the provider will be selected, scrambled, and presented to the chat room. Points are awarded to the user who guesses the emote (case-sensitive) correctly.


Additionally, this caches the list of emotes from each emote provider. To refetch the emote cache, the `[prefix]reload escramble` command can be used.

Ideally, we'd be refetching emotes at a certain interval, or even better, it would be nice to connect to BetterTTV's live updates socket to trigger refreshes when an event comes in, but would like to see how this is received before we improve on it.

This requires a new column on the timestamps CSV with the header `emote_scramble_started`.

---

This was tested with Python 3.11 with the following `requirements.txt`:

```
PythonTwitchBotFramework
requests
pandas
```

Forgot to ask if you use a different Python version. If you do, I'm happy to retest this with the version you use.